### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,20 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    redirect_to root_path
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,15 +22,16 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-  def edit
-    @item = Item.find(params[:id])
-  end
 
-  def destroy
-    item = Item.find(params[:id])
-    item.destroy
-    redirect_to root_path
-  end
+#  def edit
+#    @item = Item.find(params[:id])
+#  end
+
+#  def destroy
+#    item = Item.find(params[:id])
+#    item.destroy
+#    redirect_to root_path
+#  end
 
   private
 
@@ -40,3 +41,7 @@ class ItemsController < ApplicationController
           .merge(user_id: current_user.id)
   end
 end
+
+
+
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :items
+
   with_options presence: true do
     # ニックネーム
     validates :nickname

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
     <% if @items.present? %>
     <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
            <%= image_tag item.image, class: 'item-img' if item.image.attached? %>
           

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,7 @@
       <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag @item.image, class: 'item-box-img' if @item.image.attached? %>
+      <%= image_tag @item.image, class: 'item-box-img'%>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,9 +25,9 @@
 
   <% if user_signed_in? %>
     <% if current_user.id == @item.user_id %>
-      <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
         <% else%>
           <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>
@@ -99,9 +99,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class: 'item-box-img' if @item.image.attached? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,55 +16,51 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.delivery_fee.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+  <% if user_signed_in? %>
+    <% if current_user.id == @item.user_id %>
+      <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
+        <% else%>
+          <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <% end %>
+  <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name  %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name  %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -91,7 +87,7 @@
       </p>
       <button type="submit" class="comment-btn">
         <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
-        <span>コメントする<span>
+        <span>コメントする</span>
       </button>
     </form>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,10 +18,10 @@
       <%# ログインの有無で表示が変わるように分岐する%>
       <% if user_signed_in? %>
         <li><%= link_to current_user.nickname, "#", class: "user-nickname"%></li>
-        <li><%= link_to 'ログアウト', "users/sign_out", data: {turbo_method: :delete}, class: "logout"%></li>
+        <li><%= link_to 'ログアウト', destroy_user_session_path , data: {turbo_method: :delete}, class: "logout"%></li>
       <% else %>
-        <li><%= link_to 'ログイン', "users/sign_in", class: "login" %></li>
-        <li><%= link_to '新規登録', "users/sign_up", class: "sign-up" %></li>
+        <li><%= link_to 'ログイン', new_user_session_path , class: "login" %></li>
+        <li><%= link_to '新規登録', new_user_registration_path , class: "sign-up" %></li>
       <% end %>
     </ul>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,5 @@ Rails.application.routes.draw do
   devise_for :users
   root "items#index"
 
-  resources :items, only: [:index, :new, :create]
+  resources :items, only:[:index, :new, :show, :edit, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,5 @@ Rails.application.routes.draw do
   devise_for :users
   root "items#index"
 
-  resources :items, only:[:index, :new, :show]
+  resources :items, only:[:index, :new, :create, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,5 @@ Rails.application.routes.draw do
   devise_for :users
   root "items#index"
 
-  resources :items, only:[:index, :new, :show, :edit, :destroy]
+  resources :items, only:[:index, :new, :show]
 end


### PR DESCRIPTION
#what
商品詳細表示機能

#why
商品詳細表示ページにて、商品の詳細情報を表示するため。

【Gyazo】
※商品購入機能の実装が済んでいないため、「ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画」はURL添付梨といたします。

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/f9936eee991bef38fde1739497cc0fd5

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/fcee62fa1759d7b3052aa4db68e976d6

ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/6f91eec2043f5d627d0c7366605e7a1c